### PR TITLE
Specify linker and compiler execs in the same way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ extensions = [
 class build_ext_subclass(build_ext):
     user_options = build_ext.user_options + \
             [
-            ('ldshared', None, "LDSHARED"),
             ('mpicc', None, 'MPICC')
             ]
     def initialize_options(self):
@@ -47,8 +46,6 @@ class build_ext_subclass(build_ext):
         compiler = "mpicc"
         self.mpicc = os.environ.get('MPICC', compiler)
 
-        self.ldshared = os.environ.get('LDSHARED', 
-                self.mpicc + ' -shared')
         build_ext.initialize_options(self)    
 
     def finalize_options(self):
@@ -61,7 +58,7 @@ class build_ext_subclass(build_ext):
     def build_extensions(self):
         # turns out set_executables only works for linker_so, but for compiler_so
         self.compiler.compiler_so[0] = self.mpicc
-        self.compiler.set_executables(linker_so=self.ldshared)
+        self.compiler.linker_so[0] = self.mpicc
         build_pfft(self.pfft_build_dir, self.mpicc, ' '.join(self.compiler.compiler_so[1:]))
         link_objects = [ 
                 'libpfft.a', 


### PR DESCRIPTION
In "build_ext_subclass.build_extensions", set the first element of
"compiler.linker_so" equal to "mpicc" but leave the remaining elements
untouched. This was already done at the compile stage with
"compiler.compiler_so".

On OS X El Capitan this fixes linking errors where routines provided by
"libpython*.dylib" weren't found. I have also tested this on Fedora 23.