### PR TITLE
Fix build on Apple Silicon (ARM64) by updating config.sub/guess

### DIFF
--- a/depends/install_pfft.sh
+++ b/depends/install_pfft.sh
@@ -37,6 +37,17 @@ fi
 gzip -dc $ROOT/depends/pfft-$PFFT_VERSION.tar.gz | tar xf - -C $TMP
 cd $TMP
 
+# =====================================================================
+# Update config files to support modern architectures (e.g., Apple Silicon ARM64)
+# =====================================================================
+echo "Updating config.sub and config.guess for Apple Silicon support..."
+curl -s -L -o pfft-${PFFT_VERSION}/build-aux/config.sub "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"
+curl -s -L -o pfft-${PFFT_VERSION}/build-aux/config.guess "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess"
+
+curl -s -L -o pfft-${PFFT_VERSION}/fftw3/config.sub "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"
+curl -s -L -o pfft-${PFFT_VERSION}/fftw3/config.guess "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess"
+# =====================================================================
+
 (
 mkdir -p double;cd double
 


### PR DESCRIPTION
### Description
This PR fixes a build issue that occurs on modern macOS machines with Apple Silicon (M1/M2/M3/M4 chips). 

Currently, when `pip` or `setup.py` attempts to build the package on an `arm64-apple` architecture, the embedded configuration files inside the downloaded `pfft` and `fftw3` tarball are too old to recognize the ARM64 architecture, resulting in the following fatal error:
`Invalid configuration 'arm64-apple-darwin': machine 'arm64-apple' not recognized`

### Changes Made
Added a few lines in `depends/install_pfft.sh` right after the tarball is extracted. It downloads the latest `config.sub` and `config.guess` directly from the official GCC mirror and replaces the outdated ones in both the `pfft` root and the embedded `fftw3` directory.

This allows the `./configure` step to successfully identify the architecture and compile the C code without issues.